### PR TITLE
Pushing doctrine service provider into IslandoraServiceProvider

### DIFF
--- a/src/IslandoraServiceProvider.php
+++ b/src/IslandoraServiceProvider.php
@@ -6,6 +6,7 @@ use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Monolog\Logger;
 use Monolog\Handler\NullHandler;
+use Silex\Provider\DoctrineServiceProvider;
 use Silex\Provider\MonologServiceProvider;
 use Silex\Provider\ServiceControllerServiceProvider;
 use Silex\Provider\SecurityServiceProvider;
@@ -43,6 +44,13 @@ class IslandoraServiceProvider implements ServiceProviderInterface
         }
 
         $app->register(new ServiceControllerServiceProvider());
+
+        if (isset($config['db.options'])) {
+            $app->register(
+                new DoctrineServiceProvider(),
+                ['db.options' => $config['db.options']]
+            );
+        }
 
         $app['crayfish.cmd_execute_service'] = function ($app) {
             return new CmdExecuteService(


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/604

# What does this Pull Request do?

Registers the DoctrineServiceProvider from Silex if the proper configuration elements exist.

# What's new?
A conditional in `register` that checks to see if db configuration is present, and if so, registers the DoctrineServiceProvider.

# How should this be tested?

It's hard to manually test Crayfish-Commons code in isolation.  If this gets in fast, I'll update https://github.com/Islandora-CLAW/Crayfish/pull/26 and that can be tested.  If not so fast, then I'll add it to the upcoming PR to Crayfish for flushing metadata to Fedora and it can be tested there.

# Interested parties
@Islandora-CLAW/committers