### PR TITLE
Modify how we load DB configuraiton, so we can support other databases.

### DIFF
--- a/src/Provider/IslandoraServiceProvider.php
+++ b/src/Provider/IslandoraServiceProvider.php
@@ -97,21 +97,21 @@ class IslandoraServiceProvider implements ServiceProviderInterface
     protected function registerDbOptions($container)
     {
         $container['db.options'] = function ($container) {
-            $setoption = function (&$settings, $container, $name) {
-                if (isset($container["crayfish.db.options.$name"])) {
-                    $settings[$name] = $container["crayfish.db.options.$name"];
+            $match = "crayfish.db.options.";
+            $set_option = function (&$settings, $container, $key) use ($match) {
+                $name = substr($key, strlen($match));
+                if (isset($container[$key])) {
+                    $settings[$name] = $container[$key];
                 }
             };
 
             $settings = [];
-            $setoption($settings, $container, 'host');
-            $setoption($settings, $container, 'port');
-            $setoption($settings, $container, 'dbname');
-            $setoption($settings, $container, 'user');
-            $setoption($settings, $container, 'password');
-            $setoption($settings, $container, 'charset');
-            $setoption($settings, $container, 'path');
-            $setoption($settings, $container, 'url');
+            $keys = $container->keys();
+            foreach ($keys as $key) {
+                if (strpos($key, $match) === 0) {
+                        $set_option($settings, $container, $key);
+                }
+            }
 
             return $settings;
         };

--- a/tests/Provider/IslandoraServiceProviderTest.php
+++ b/tests/Provider/IslandoraServiceProviderTest.php
@@ -31,11 +31,17 @@ class IslandoraServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Logger::class, $this->container['monolog']);
     }
 
+    public function testDoctrineOptions()
+    {
+        $this->container['crayfish.db.options.foo'] = 'bar';
+        $this->assertArrayHasKey('foo', $this->container['db.options']);
+        $this->assertEquals('bar', $this->container['db.options']['foo']);
+    }
+
     public function testDoctrine()
     {
         // doctrine uses logger
         $this->container['crayfish.log.level'] = 'none';
-
         $this->assertInstanceOf(Connection::class, $this->container['db']);
     }
 


### PR DESCRIPTION
## GitHub Issue:

https://github.com/Islandora-Devops/claw-playbook/pull/14

## What does this Pull Request do?

Updates how Crayfish-Commons loads our YAML configuration, so that we can set DB options. This was causing problems for the PGSQL patch for the claw playbook.

# How should this be tested?

Set DB options that were not being respected before like `driver` and see that they are now correctly put into the form accepted by our DB layer.

# Interested parties
@Islandora-CLAW/committers