### PR TITLE
Alter JWT claims to use standard ones.

### DIFF
--- a/src/Syn/JwtAuthenticator.php
+++ b/src/Syn/JwtAuthenticator.php
@@ -72,16 +72,16 @@ class JwtAuthenticator extends AbstractGuardAuthenticator
 
         // Check correct properties
         $payload = $jwt->getPayload();
-        if (!isset($payload['uid'])) {
-            $this->logger->info('Token missing uid');
+        if (!isset($payload['webid'])) {
+            $this->logger->info('Token missing webid');
             return null;
         }
-        if (!isset($payload['url'])) {
-            $this->logger->info('Token missing url');
+        if (!isset($payload['iss'])) {
+            $this->logger->info('Token missing iss');
             return null;
         }
-        if (!isset($payload['name'])) {
-            $this->logger->info('Token missing name');
+        if (!isset($payload['sub'])) {
+            $this->logger->info('Token missing sub');
             return null;
         }
         if (!isset($payload['roles'])) {
@@ -105,7 +105,7 @@ class JwtAuthenticator extends AbstractGuardAuthenticator
         return [
             'token' => $token,
             'jwt' => $jwt,
-            'name' => $payload['name'],
+            'name' => $payload['sub'],
             'roles' => $payload['roles']
         ];
     }
@@ -126,7 +126,7 @@ class JwtAuthenticator extends AbstractGuardAuthenticator
 
         $jwt = $credentials['jwt'];
         $payload = $jwt->getPayload();
-        $url = $payload['url'];
+        $url = $payload['iss'];
         if (isset($this->sites[$url])) {
             $site = $this->sites[$url];
         } elseif (isset($this->sites['default'])) {

--- a/tests/Syn/JwtAuthenticatorTest.php
+++ b/tests/Syn/JwtAuthenticatorTest.php
@@ -138,9 +138,9 @@ class JwtAuthenticatorTest extends \PHPUnit_Framework_TestCase
     public function testHeaderTokenFields()
     {
         $data = [
-            'uid' => 1,
-            'url' => 'https://foo.com',
-            'name' => 'charlie',
+            'webid' => 1,
+            'iss' => 'https://foo.com',
+            'sub' => 'charlie',
             'roles' => ['bartender', 'exterminator'],
             'iat' => 1,
             'exp' => 1,
@@ -148,15 +148,15 @@ class JwtAuthenticatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_array($this->headerTokenHelper($data)));
 
         $missing = $data;
-        unset($missing['uid']);
+        unset($missing['webid']);
         $this->assertNull($this->headerTokenHelper($missing));
 
         $missing = $data;
-        unset($missing['url']);
+        unset($missing['iss']);
         $this->assertNull($this->headerTokenHelper($missing));
 
         $missing = $data;
-        unset($missing['name']);
+        unset($missing['sub']);
         $this->assertNull($this->headerTokenHelper($missing));
 
         $missing = $data;
@@ -203,9 +203,9 @@ class JwtAuthenticatorTest extends \PHPUnit_Framework_TestCase
     public function testJwtAuthentication()
     {
         $data = [
-            'uid' => 1,
-            'url' => 'https://foo.com',
-            'name' => 'charlie',
+            'webid' => 1,
+            'iss' => 'https://foo.com',
+            'sub' => 'charlie',
             'roles' => ['bartender', 'exterminator'],
             'iat' => 1,
             'exp' => 1,
@@ -217,9 +217,9 @@ class JwtAuthenticatorTest extends \PHPUnit_Framework_TestCase
     public function testJwtAuthenticationInvalidJwt()
     {
         $data = [
-            'uid' => 1,
-            'url' => 'https://foo.com',
-            'name' => 'charlie',
+            'webid' => 1,
+            'iss' => 'https://foo.com',
+            'sub' => 'charlie',
             'roles' => ['bartender', 'exterminator'],
             'iat' => 1,
             'exp' => 1,
@@ -231,9 +231,9 @@ class JwtAuthenticatorTest extends \PHPUnit_Framework_TestCase
     public function testJwtAuthenticationNoSite()
     {
         $data = [
-            'uid' => 1,
-            'url' => 'https://www.pattyspub.ca/',
-            'name' => 'charlie',
+            'webid' => 1,
+            'iss' => 'https://www.pattyspub.ca/',
+            'sub' => 'charlie',
             'roles' => ['bartender', 'exterminator'],
             'iat' => 1,
             'exp' => 1,
@@ -245,9 +245,9 @@ class JwtAuthenticatorTest extends \PHPUnit_Framework_TestCase
     public function testJwtAuthenticationDefaultSite()
     {
         $data = [
-            'uid' => 1,
-            'url' => 'https://www.pattyspub.ca/',
-            'name' => 'charlie',
+            'webid' => 1,
+            'iss' => 'https://www.pattyspub.ca/',
+            'sub' => 'charlie',
             'roles' => ['bartender', 'exterminator'],
             'iat' => 1,
             'exp' => 1,


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/736

Depends on: https://github.com/Islandora-CLAW/islandora/pull/73
Related to: https://github.com/Islandora-CLAW/Syn/pull/11

# What does this Pull Request do?

Alters expected claims in an Islandora CLAW JWT.

# What's new?

`uid` -> `webid`

`name` -> `sub`

`url` -> `iss`

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

See the testing instructions here (https://github.com/Islandora-CLAW/Syn/pull/11) they pull in the changes to Syn, islandora and Crayfish-Commons.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers