### PR TITLE
Move GeminiClient to Crayfish Commons

### DIFF
--- a/src/Client/GeminiClient.php
+++ b/src/Client/GeminiClient.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: daniel
+ * Date: 11/07/17
+ * Time: 11:43 AM
+ */
+
+namespace Islandora\Crayfish\Commons\Client;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class GeminiClient
+ * @package Islandora\Milliner\Gemini
+ */
+class GeminiClient
+{
+    /**
+     * @var \GuzzleHttp\Client
+     */
+    protected $client;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $log;
+
+    /**
+     * GeminiClient constructor.
+     * @param \GuzzleHttp\Client $client
+     * @param \Psr\Log\LoggerInterface $log
+     */
+    public function __construct(Client $client, LoggerInterface $log)
+    {
+        $this->client = $client;
+        $this->log = $log;
+    }
+
+    public static function create($base_url, LoggerInterface $log)
+    {
+        $trimmed = trim($base_url);
+        $with_trailing_slash = rtrim($trimmed, '/') . '/';
+        return new GeminiClient(
+            new Client(['base_uri' => $with_trailing_slash]),
+            $log
+        );
+    }
+
+    /**
+     * Gets a pair of drupal/fedora urls for a UUID.
+     * @param $uuid
+     * @param $token
+     *
+     * @throws \GuzzleHttp\Exception\RequestException
+     *
+     * @return array|null
+     */
+    public function getUrls(
+        $uuid,
+        $token = null
+    ) {
+        try {
+            if (empty($token)) {
+                $response = $this->client->get($uuid);
+            } else {
+                $response = $this->client->get($uuid, [
+                    'headers' => [
+                        'Authorization' => $token,
+                    ],
+                ]);
+            }
+
+            $this->log->debug("Gemini GET response", [
+                'uuid' => $uuid,
+                'response' => $response,
+            ]);
+
+            return json_decode($response->getBody(), true);
+        } catch (RequestException $e) {
+            if ($e->getResponse()->getStatusCode() == 404) {
+                return null;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Mints a new Fedora URL for a UUID.
+     * @param $uuid
+     * @param $token
+     *
+     * @throws \GuzzleHttp\Exception\RequestException
+     *
+     * @return string
+     */
+    public function mintFedoraUrl(
+        $uuid,
+        $token = null
+    ) {
+        $headers = ['Content-Type' => 'text/plain'];
+
+        if (!empty($token)) {
+            $headers['Authorization'] = $token;
+        }
+
+        $response = $this->client->post('', [
+            'body' => $uuid,
+            'headers' => $headers,
+        ]);
+
+        $this->log->debug("Gemini POST response", [
+            'uuid' => $uuid,
+            'response' => $response,
+        ]);
+
+        return (string)$response->getBody();
+    }
+
+    /**
+     * Saves a pair of drupal/fedora urls for a UUID.
+     * @param $uuid
+     * @param $drupal
+     * @param $fedora
+     * @param $token
+     *
+     * @throws \GuzzleHttp\Exception\RequestException
+     *
+     * @return bool
+     */
+    public function saveUrls(
+        $uuid,
+        $drupal,
+        $fedora,
+        $token = null
+    ) {
+        $body = json_encode(['drupal' => $drupal, 'fedora' => $fedora]);
+
+        $headers = ['Content-Type' => 'application/json'];
+
+        if (!empty($token)) {
+            $headers['Authorization'] = $token;
+        }
+
+        $response = $this->client->put($uuid, [
+            'body' => $body,
+            'headers' => $headers,
+        ]);
+
+        $this->log->debug("Gemini PUT response", [
+            'uuid' => $uuid,
+            'response' => $response,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Deletes a pair of drupal/fedora urls for a UUID.
+     * @param $uuid
+     * @param $token
+     *
+     * @throws \GuzzleHttp\Exception\RequestException
+     *
+     * @return bool
+     */
+    public function deleteUrls(
+        $uuid,
+        $token = null
+    ) {
+        $headers = [];
+
+        if (!empty($token)) {
+            $headers['Authorization'] = $token;
+        }
+
+        $response = $this->client->delete($uuid, [
+            'headers' => $headers,
+        ]);
+
+        $this->log->debug("Gemini DELETE response", [
+            'uuid' => $uuid,
+            'response' => $response,
+        ]);
+
+        return true;
+    }
+
+  /**
+   * Find the URLs given one of them.
+   * @param $uri
+   *   The Drupal or Fedora URI.
+   * @param null $token
+   *   Authorization token.
+   *
+   * @return null|string[]
+   *
+   */
+    public function findByUri(
+        $uri,
+        $token = null
+    ) {
+        $headers['X-Islandora-URI'] = $uri;
+
+        if (!empty($token)) {
+            $headers["Authorization"] = $token;
+        }
+
+        try {
+            $response = $this->client->get('by_uri', [
+            'headers' => $headers,
+            ]);
+        } catch (ClientException $e) {
+            // Got a 404
+            $this->log->debug('Gemini findByURI 404 response', [
+            'uri' => $uri,
+            ]);
+            return null;
+        }
+
+        $this->log->debug("Gemini findByURI response", [
+        'uri' => $uri,
+        'response' => $response,
+        ]);
+
+        return $response->getHeader('Location');
+    }
+}

--- a/tests/Client/GeminiClientTest.php
+++ b/tests/Client/GeminiClientTest.php
@@ -259,8 +259,8 @@ class GeminiClientTest extends TestCase
    */
     public function testCreate()
     {
-      $base_url = 'http://localhost:1234/example';
-      $client = GeminiClient::create($base_url, $this->logger);
-      $this->assertTrue($client instanceof GeminiClient);
+        $base_url = 'http://localhost:1234/example';
+        $client = GeminiClient::create($base_url, $this->logger);
+        $this->assertTrue($client instanceof GeminiClient);
     }
 }

--- a/tests/Client/GeminiClientTest.php
+++ b/tests/Client/GeminiClientTest.php
@@ -41,6 +41,7 @@ class GeminiClientTest extends TestCase
 
     /**
      * @covers ::getUrls
+     * @covers ::__construct
      */
     public function testGetUrls()
     {
@@ -251,5 +252,15 @@ class GeminiClientTest extends TestCase
             $out,
             "Gemini client must return null when 404 is returned."
         );
+    }
+
+  /**
+   * @covers ::create
+   */
+    public function testCreate()
+    {
+      $base_url = 'http://localhost:1234/example';
+      $client = GeminiClient::create($base_url, $this->logger);
+      $this->assertTrue($client instanceof GeminiClient);
     }
 }

--- a/tests/Client/GeminiClientTest.php
+++ b/tests/Client/GeminiClientTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Islandora\Crayfish\Commons\Client\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Islandora\Crayfish\Commons\Client\GeminiClient;
+use Monolog\Handler\NullHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class GeminiClientTest
+ * @package Islandora\Crayfish\Commons\Client\Tests
+ * @coversDefaultClass Islandora\Crayfish\Commons\Client\GeminiClient
+ */
+class GeminiClientTest extends TestCase
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->logger = new Logger('milliner');
+        $this->logger->pushHandler(new NullHandler());
+    }
+
+    /**
+     * @covers ::getUrls
+     */
+    public function testGetUrls()
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getBody()->willReturn('{"drupal" : "foo", "fedora": "bar"}');
+        $response = $response->reveal();
+
+        $client = $this->prophesize(Client::class);
+        $client->get(Argument::any(), Argument::any())->willReturn($response);
+        $client = $client->reveal();
+
+        $gemini = new GeminiClient(
+            $client,
+            $this->logger
+        );
+
+        $out = $gemini->getUrls("abc123");
+        $this->assertTrue(
+            $out['drupal'] == 'foo',
+            "Gemini client must return response unaltered.  Expected 'foo' but received {$out['drupal']}"
+        );
+        $this->assertTrue(
+            $out['fedora'] == 'bar',
+            "Gemini client must return response unaltered.  Expected 'bar' but received {$out['fedora']}"
+        );
+
+        $out = $gemini->getUrls("abc123", "some_token");
+        $this->assertTrue(
+            $out['drupal'] == 'foo',
+            "Gemini client must return response unaltered.  Expected 'foo' but received {$out['drupal']}"
+        );
+        $this->assertTrue(
+            $out['fedora'] == 'bar',
+            "Gemini client must return response unaltered.  Expected 'bar' but received {$out['fedora']}"
+        );
+    }
+
+    /**
+     * @covers ::getUrls
+     */
+    public function testGetUrlsReturnsEmptyArrayWhenNotFound()
+    {
+        $request = $this->prophesize(RequestInterface::class)->reveal();
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(404);
+        $response = $response->reveal();
+
+        $client = $this->prophesize(Client::class);
+        $client->get(Argument::any(), Argument::any())->willThrow(
+            new RequestException("Not Found", $request, $response)
+        );
+        $client = $client->reveal();
+
+        $gemini = new GeminiClient(
+            $client,
+            $this->logger
+        );
+
+        $this->assertTrue(
+            empty($gemini->getUrls("abc123")),
+            "Gemini client must return empty array if not found"
+        );
+        $this->assertTrue(
+            empty($gemini->getUrls("abc123", "some_token")),
+            "Gemini client must return empty array if not found"
+        );
+    }
+
+    /**
+     * @covers ::mintFedoraUrl
+     */
+    public function testMintFedoraUrl()
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getBody()->willReturn("http://foo.com/bar");
+        $response = $response->reveal();
+
+        $client = $this->prophesize(Client::class);
+        $client->post(Argument::any(), Argument::any())->willReturn($response);
+        $client = $client->reveal();
+
+        $gemini = new GeminiClient(
+            $client,
+            $this->logger
+        );
+
+        $url = $gemini->mintFedoraUrl("abc123");
+        $this->assertTrue(
+            $url == "http://foo.com/bar",
+            "Gemini client must return response unaltered.  Expected 'http://foo.com/bar' but received $url"
+        );
+
+        $url = $gemini->mintFedoraUrl("abc123", "some_token");
+        $this->assertTrue(
+            $url == "http://foo.com/bar",
+            "Gemini client must return response unaltered.  Expected 'http://foo.com/bar' but received $url"
+        );
+    }
+
+    /**
+     * @covers ::saveUrls
+     */
+    public function testSaveUrls()
+    {
+        $client = $this->prophesize(Client::class)->reveal();
+
+        $gemini = new GeminiClient(
+            $client,
+            $this->logger
+        );
+
+        $out = $gemini->saveUrls("abc123", "foo", "bar");
+        $this->assertTrue(
+            $out,
+            "Gemini client must return true on successful saveUrls().  Received $out"
+        );
+
+        $out = $gemini->saveUrls("abc123", "foo", "bar", "some_token");
+        $this->assertTrue(
+            $out,
+            "Gemini client must return true on successful saveUrls().  Received $out"
+        );
+    }
+
+    /**
+     * @covers ::deleteUrls
+     */
+    public function testDeleteUrls()
+    {
+        $client = $this->prophesize(Client::class)->reveal();
+
+        $gemini = new GeminiClient(
+            $client,
+            $this->logger
+        );
+
+        $out = $gemini->deleteUrls("abc123");
+        $this->assertTrue(
+            $out,
+            "Gemini client must return true on successful deleteUrls().  Received $out"
+        );
+
+        $out = $gemini->deleteUrls("abc123", "some_token");
+        $this->assertTrue(
+            $out,
+            "Gemini client must return true on successful deleteUrls().  Received $out"
+        );
+    }
+
+  /**
+   * @covers ::findByUri
+   */
+    public function testGetByUriFailed()
+    {
+        $prophesize = $this->prophesize(Client::class);
+
+        $request = new Request('GET', '/by_uri');
+        $prophesize->get(Argument::any(), Argument::any())
+        ->willThrow(new ClientException('Uri not found', $request));
+        $client = $prophesize->reveal();
+
+        $gemini = new GeminiClient(
+            $client,
+            $this->logger
+        );
+
+        $out = $gemini->findByUri('blah');
+        $this->assertNull(
+            $out,
+            "Gemini client must return null when 404 is returned."
+        );
+
+        $out = $gemini->findByUri('blah', 'some_token');
+        $this->assertNull(
+            $out,
+            "Gemini client must return null when 404 is returned."
+        );
+    }
+
+  /**
+   * @covers ::findByUri
+   */
+    public function testGetByUriOk()
+    {
+        $prophesize = $this->prophesize(Client::class);
+
+        $prophesize->get(Argument::any(), Argument::any())
+        ->willReturn(new Response(
+            200,
+            ['Location' => 'some-uri']
+        ));
+        $client = $prophesize->reveal();
+
+        $gemini = new GeminiClient(
+            $client,
+            $this->logger
+        );
+
+        $out = $gemini->findByUri('blah');
+        $this->assertNotNull(
+            $out,
+            "Gemini client must return null when 404 is returned."
+        );
+
+        $out = $gemini->findByUri('blah', 'some_token');
+        $this->assertNotNull(
+            $out,
+            "Gemini client must return null when 404 is returned."
+        );
+    }
+}


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/800

Required for: https://github.com/Islandora-CLAW/Crayfish/pull/44

# What does this Pull Request do?

Moves the GeminiClient from Milliner to CrayfishCommons and adds a `findByUrl` function.

# What's New
* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Internal tests and testing of associated PR: https://github.com/Islandora-CLAW/Crayfish/pull/44

# Interested parties
@Islandora-CLAW/committers