### PR TITLE
Update code to read pipes to eliminate deadlocks

### DIFF
--- a/tests/Islandora/Crayfish/Commons/Tests/CmdExecuteServiceTest.php
+++ b/tests/Islandora/Crayfish/Commons/Tests/CmdExecuteServiceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Islandora\Crayfish\Commons\Tests;
+
+use Islandora\Crayfish\Commons\CmdExecuteService;
+use function rewind;
+
+/**
+ * Class CmdExecuteServiceTest
+ * @package Islandora\Crayfish\Commons\Tests
+ * @coversDefaultClass \Islandora\Crayfish\Commons\CmdExecuteService
+ */
+class CmdExecuteServiceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturnsInput()
+    {
+        $cmd = new CmdExecuteService();
+        $data = fopen("php://temp", 'w+');
+        $output = $cmd->execute('echo foo', $data);
+        $this->expectOutputString("foo\n");
+        $output();
+    }
+
+    public function testReturnsData()
+    {
+        $cmd = new CmdExecuteService();
+        $data = fopen("php://temp", 'w+');
+        fwrite($data, "foo\n");
+        rewind($data);
+        $output = $cmd->execute('cat', $data);
+        $this->expectOutputString("foo\n");
+        $output();
+    }
+}


### PR DESCRIPTION
## GitHub Issue

Possible solution to:
https://github.com/Islandora-CLAW/CLAW/issues/943

## What does this Pull Request do?

This does two things:
1. It refactors our pipe handling code, to eliminate a possible deadlock where the process puts a lot of data out on STDERR while we are reading STDOUT.
2. Adds some simple tests to the `CmdExecuteService` class.

## How should this be tested?

I wrote this pretty quickly, and didn't do a lot of testing, so it for sure needs some testing. 

1. Test the existing services using `CmdExecuteService` still work okay when applying this patch.
2. Test if ffmpeg now runs correctly using `CmdExecuteService`.

## Interested parties
@Natkeeran @dannylamb 