### PR TITLE
update travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Crayfish Commons
 
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%205.6-8892BF.svg?style=flat-square)](https://php.net/)
-[![Build Status](https://travis-ci.org/Islandora-CLAW/Crayfish-Commons.svg?branch=master)](https://travis-ci.org/Islandora-CLAW/Crayfish-Commons)
+[![Build Status](https://travis-ci.com/Islandora-CLAW/Crayfish-Commons.svg?branch=master)](https://travis-ci.com/Islandora-CLAW/Crayfish-Commons)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE)
 [![codecov](https://codecov.io/gh/Islandora-CLAW/Crayfish-Commons/branch/master/graph/badge.svg)](https://codecov.io/gh/Islandora-CLAW/Crayfish-Commons)


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#950

# What does this Pull Request do?

Grabs the travis badge from travis-ci.com instead of travis-ci.org

# Interested parties
@Islandora-CLAW/committers

_Please delete branch after merging_