### PR TITLE
Tests for CmdExecuteService

### DIFF
--- a/src/CmdExecuteService.php
+++ b/src/CmdExecuteService.php
@@ -36,7 +36,8 @@ class CmdExecuteService
      *
      * @return resource;
      */
-    public function getOutputStream() {
+    public function getOutputStream()
+    {
         return $this->output;
     }
 

--- a/src/CmdExecuteService.php
+++ b/src/CmdExecuteService.php
@@ -18,12 +18,26 @@ class CmdExecuteService
     protected $log;
 
     /**
+     * @var resource
+     */
+    protected $output;
+
+    /**
      * Executor constructor.
      * @param LoggerInterface $log
      */
     public function __construct(LoggerInterface $log = null)
     {
         $this->log = $log;
+    }
+
+    /**
+     * $output getter.
+     *
+     * @return resource;
+     */
+    public function getOutputStream() {
+        return $this->output;
     }
 
     /**
@@ -75,7 +89,7 @@ class CmdExecuteService
         // Wait for process to finish while reading STDOUT to a temp stream.
         // Otherwise the process can block indefinitely if STODUT gets bigger
         // than 4kb.
-        $output = fopen("php://temp", 'w+');
+        $this->output = fopen("php://temp", 'w+');
         $exit_code = null;
         while ($exit_code === null) {
             $status = proc_get_status($process);
@@ -85,7 +99,7 @@ class CmdExecuteService
 
             $chunk = stream_get_contents($pipes[1]);
             if ($chunk !== false) {
-                fwrite($output, $chunk);
+                fwrite($this->output, $chunk);
             }
         }
 
@@ -95,7 +109,7 @@ class CmdExecuteService
         // On error, extract message from STDERR and throw an exception.
         if ($exit_code != 0) {
             $msg = stream_get_contents($pipes[2]);
-            $this->cleanup($pipes, $output, $process);
+            $this->cleanup($pipes, $this->output, $process);
             if ($this->log) {
                 $this->log->error('Process exited with non-zero code.', [
                   'exit_code' => $exit_code,
@@ -106,14 +120,14 @@ class CmdExecuteService
         }
 
         // Return a function that streams the output.
-        return function () use ($pipes, $output, $process) {
-            rewind($output);
-            while (!feof($output)) {
-                echo fread($output, 1024);
+        return function () use ($pipes, $process) {
+            rewind($this->output);
+            while (!feof($this->output)) {
+                echo fread($this->output, 1024);
                 ob_flush();
                 flush();
             }
-            $this->cleanup($pipes, $output, $process);
+            $this->cleanup($pipes, $this->output, $process);
         };
     }
 
@@ -123,7 +137,7 @@ class CmdExecuteService
         fclose($pipes[2]);
 
         // Close the temp output stream.
-        fclose($output);
+        fclose($this->output);
 
         // Close the process
         proc_close($process);

--- a/tests/ApixMiddlewareTest.php
+++ b/tests/ApixMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Islandora\Crayfish\Commons\Tests;
+namespace Islandora\Crayfish\Commons\tests;
 
 use Islandora\Chullo\IFedoraApi;
 use Islandora\Crayfish\Commons\ApixMiddleware;
@@ -10,16 +10,8 @@ use Psr\Http\Message\ResponseInterface;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * Class ApixMiddlewareTest
- * @package Islandora\Crayfish\Commons\Tests
- * @coversDefaultClass \Islandora\Crayfish\Commons\ApixMiddleware
- */
 class ApixMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers ::before
-     */
     public function testReturnsFedoraError()
     {
         // Mock a Fedora response.
@@ -66,9 +58,6 @@ class ApixMiddlewareTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers ::before
-     */
     public function testReturns400IfNoApixLdpResourceHeader()
     {
         // Mock a FedoraApi.

--- a/tests/CmdExecuteServiceTest.php
+++ b/tests/CmdExecuteServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Islandora\Crayfish\Commons\tests;
+
+use Islandora\Crayfish\Commons\CmdExecuteService;
+use Monolog\Logger;
+use Monolog\Handler\NullHandler;
+
+class CmdExecuteServiceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExecuteWithResource()
+    {
+        $logger = new Logger('test');
+        $logger->pushHandler(new NullHandler());
+        $service = new CmdExecuteService($logger);
+
+        $string = "apple\npear\nbanana";
+        $data = fopen('php://memory','r+');
+        fwrite($data, $string);
+        rewind($data);
+
+        $command = 'sort -';
+
+        $callback = $service->execute($command, $data);
+
+        $this->assertTrue(is_callable($callback), "execute() must return a callable.");
+
+        $output = $service->getOutputStream();
+        rewind($output);
+        $actual = stream_get_contents($output);
+
+        $this->assertTrue($actual == "apple\nbanana\npear\n", "Output stream should have sorted the list, received $actual");
+
+        // Call the callback just to close the streams/process.
+        $callback();
+    }
+
+    public function testExecuteWithoutResource()
+    {
+        $logger = new Logger('test');
+        $logger->pushHandler(new NullHandler());
+        $service = new CmdExecuteService($logger);
+
+        $command = 'echo "derp"';
+        $callback = $service->execute($command, "");
+
+        $this->assertTrue(is_callable($callback), "execute() must return a callable.");
+
+        $output = $service->getOutputStream();
+        rewind($output);
+        $actual = stream_get_contents($output);
+
+        $this->assertTrue($actual == "derp\n", "Output stream should contain 'derp', received $actual");
+
+        // Call the callback just to close the streams/process.
+        $callback();
+    }
+}

--- a/tests/CmdExecuteServiceTest.php
+++ b/tests/CmdExecuteServiceTest.php
@@ -15,7 +15,7 @@ class CmdExecuteServiceTest extends \PHPUnit_Framework_TestCase
         $service = new CmdExecuteService($logger);
 
         $string = "apple\npear\nbanana";
-        $data = fopen('php://memory','r+');
+        $data = fopen('php://memory', 'r+');
         fwrite($data, $string);
         rewind($data);
 
@@ -29,7 +29,10 @@ class CmdExecuteServiceTest extends \PHPUnit_Framework_TestCase
         rewind($output);
         $actual = stream_get_contents($output);
 
-        $this->assertTrue($actual == "apple\nbanana\npear\n", "Output stream should have sorted the list, received $actual");
+        $this->assertTrue(
+            $actual == "apple\nbanana\npear\n",
+            "Output stream should have sorted the list, received $actual"
+        );
 
         // Call the callback just to close the streams/process.
         $callback();


### PR DESCRIPTION
**GitHub Issue**: Part of https://github.com/Islandora-CLAW/CLAW/issues/943

* Follow up to https://github.com/Islandora-CLAW/Crayfish-Commons/pull/20

# What does this Pull Request do?

Refactors `CmdExecuteService` to make it easier to test.  Adds tests for `CmdExecuteService`.

# What's new?

A getter for `CmdExecuteService`'s output stream.

# How should this be tested?

Codecov should be happy.

# Interested parties
@whikloj @Natkeeran @Islandora-CLAW/committers