### PR TITLE
Fix the response as expected by the test.

### DIFF
--- a/ApixMiddleware.php
+++ b/ApixMiddleware.php
@@ -62,6 +62,10 @@ class ApixMiddleware implements EventSubscriberInterface
         if (!$request->headers->has("Apix-Ldp-Resource")) {
             $this->log->debug("No Apix-Ldp-Resource header present, no fedora_resource set");
             $request->attributes->set('fedora_resource', false);
+            $event->setResponse(new Response(
+                "Malformed request, no Apix-Ldp-Resource header present",
+                400
+            ));
             return;
         }
 


### PR DESCRIPTION
`Islandora\Crayfish\Commons\Tests\ApixMiddlewareTest::testReturns400IfNoApixLdpResourceHeader()` expects an HTTP 400 to be emitted; however, it was not being done.

# What does this Pull Request do?

Restores behaviour being tested that was changed in the [move to Symfony bundles](https://github.com/Islandora/Crayfish-Commons/pull/49/files#diff-4bad5a178c68c175c5d9edf8796b2bbfaefa1f0443be2475ad1e676f3a9ef966L50-R65)

* **Related GitHub Issue**: (link)

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes x feature to such that y
* Added x
* Removed y
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
