### PR TITLE
Feature/better escaping

### DIFF
--- a/CmdExecuteService.php
+++ b/CmdExecuteService.php
@@ -74,7 +74,10 @@ class CmdExecuteService
         $pipes = [];
 
         // Start process, telling it to use STDIN for input and STDOUT for output.
-        $cmd = escapeshellcmd($cmd);
+        $cmd = match (gettype($cmd)) {
+            'array' => $cmd,
+            default => escapeshellcmd($cmd),
+        };
         $process = proc_open($cmd, $descr, $pipes);
 
         // Get the data into pipe only if data is resource

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Crayfish](https://user-images.githubusercontent.com/2371345/48163075-11c6cf80-e2b5-11e8-8b5b-991b366014a5.png)
 # Crayfish Commons
 
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF.svg?style=flat-square)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
 [![Build Status](https://github.com/islandora/crayfish-commons/actions/workflows/build-2.x.yml/badge.svg)](https://github.com/Islandora/crayfish-commons/actions)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE)
@@ -18,7 +18,7 @@ Shared Classes include:
 
 ## Requirements
 
-* PHP 7.4+
+* PHP 8.0+
 * [Composer](https://getcomposer.org/)
 
 ## Installation

--- a/Tests/CmdExecuteServiceTest.php
+++ b/Tests/CmdExecuteServiceTest.php
@@ -7,7 +7,25 @@ use Islandora\Crayfish\Commons\CmdExecuteService;
 class CmdExecuteServiceTest extends AbstractCrayfishCommonsTestCase
 {
 
-    public function testExecuteWithResource()
+    public function dataProviderWithResource()
+    {
+        return [
+            'test as string' => [
+                'sort -',
+            ],
+            'test as array' => [
+                [
+                    'sort',
+                    '-',
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderWithResource
+     */
+    public function testExecuteWithResource(string|array $command)
     {
         $service = new CmdExecuteService($this->logger);
 
@@ -15,8 +33,6 @@ class CmdExecuteServiceTest extends AbstractCrayfishCommonsTestCase
         $data = fopen('php://memory', 'r+');
         fwrite($data, $string);
         rewind($data);
-
-        $command = 'sort -';
 
         $callback = $service->execute($command, $data);
 
@@ -36,11 +52,28 @@ class CmdExecuteServiceTest extends AbstractCrayfishCommonsTestCase
         $callback();
     }
 
-    public function testExecuteWithoutResource()
+    public function dataProviderWithoutResource()
+    {
+        return [
+          'test as string' => [
+            'echo "derp"',
+          ],
+          'test as array' => [
+            [
+              'echo',
+              'derp',
+            ],
+          ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderWithoutResource
+     */
+    public function testExecuteWithoutResource(string|array $command)
     {
         $service = new CmdExecuteService($this->logger);
 
-        $command = 'echo "derp"';
         $callback = $service->execute($command, "");
 
         $this->assertTrue(is_callable($callback), "execute() must return a callable.");


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Allows command invocations to be passed as arrays, in order to make use of PHP's improved escaping mechanisms (as of PHP 7.4, in [`proc_open()`](https://www.php.net/manual/en/function.proc-open.php))

# What's new?

Callers may now pass commands to be executed as an array.

* Changes x feature to such that y
* Added x
* Removed y
* Does this change require documentation to be updated? Not aware of any.
* Does this change add any new dependencies? Not really, though the use of PHP 8.0's `match()` might be pulling up the minimum PHP that things will run against. We only test on 8.1+, so probably not an issue?
* Does this change require any other modifications to be made to the repository (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Shouldn't, unless running PHP <8.0.

# How should this be tested?

Run the tests. Can be run on each commit individually by checking out and then running. The first commit, the "string" invocations should work and the "array" invocations fail. The second commit has both working.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
